### PR TITLE
Fix Round thermostat Auto mode; Bump plugin version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-honeywell-home",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-honeywell-home",
-      "version": "10.0.1",
+      "version": "10.0.2",
       "funding": [
         {
           "type": "Paypal",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Honeywell Home",
   "name": "homebridge-honeywell-home",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "description": "The [Homebridge](https://homebridge.io) Honeywell Home plugin allows you to access your [Honeywell Home](https://honeywellhome.com) device(s) from HomeKit.",
   "author": "donavanbecker",
   "license": "Apache-2.0",


### PR DESCRIPTION
The Round Thermostat that does not report 'Auto' in the available modes
should not be setting the autoChangeoverActive status as this will force
the mode into 'Auto' which will be rejected by the thermostat as an
unsupported mode.

Additionally, always refresh the state of the thermostat from the API
when pushing changes which will allow HomeKit to reflect the correct
state if the push changes API fails

Issue:
https://github.com/donavanbecker/homebridge-honeywell-home/issues/554