### PR TITLE
v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/)
 
+## [Version 1.4.1](https://github.com/donavanbecker/homebridge-resideo/releases/tag/v1.4.1) (2023-08-19)
+
+## What's Changes
+- Fixed LeakSensor Inital status not pulling on restart.
+- Housekeeping and updated dependencies.
+
+**Full Changelog**: https://github.com/donavanbecker/homebridge-resideo/compare/v1.4.0...v1.4.1
+
 ## [Version 1.4.0](https://github.com/donavanbecker/homebridge-resideo/releases/tag/v1.4.0) (2023-08-19)
 
 ## What's Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-resideo",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-resideo",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "funding": [
         {
           "type": "Paypal",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Resideo",
   "name": "homebridge-resideo",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "The [Homebridge](https://homebridge.io) Resideo plugin allows you to access your [Resideo](https://resideo.com) device(s) from HomeKit.",
   "author": "donavanbecker",
   "license": "Apache-2.0",

--- a/src/devices/leaksensors.ts
+++ b/src/devices/leaksensors.ts
@@ -155,6 +155,7 @@ export class LeakSensor {
     }
 
     // Retrieve initial values and updateHomekit
+    this.refreshStatus();
     this.updateHomeKitCharacteristics();
 
     // Start an update interval


### PR DESCRIPTION
## [Version 1.4.1](https://github.com/donavanbecker/homebridge-resideo/releases/tag/v1.4.1) (2023-08-19)

## What's Changes
- Fixed LeakSensor Inital status not pulling on restart.
- Housekeeping and updated dependencies.

**Full Changelog**: https://github.com/donavanbecker/homebridge-resideo/compare/v1.4.0...v1.4.1