### PR TITLE
Bugfix/oauth api change

### DIFF
--- a/src/settings.test.ts
+++ b/src/settings.test.ts
@@ -12,19 +12,19 @@ describe('settings', () => {
   })
 
   it('should have correct AuthorizeURL', () => {
-    expect(settings.AuthorizeURL).toBe('https://api.honeywell.com/oauth2/authorize?')
+    expect(settings.AuthorizeURL).toBe('https://api.honeywellhome.com/oauth2/authorize?')
   })
 
   it('should have correct TokenURL', () => {
-    expect(settings.TokenURL).toBe('https://api.honeywell.com/oauth2/token')
+    expect(settings.TokenURL).toBe('https://api.honeywellhome.com/oauth2/token')
   })
 
   it('should have correct LocationURL', () => {
-    expect(settings.LocationURL).toBe('https://api.honeywell.com/v2/locations')
+    expect(settings.LocationURL).toBe('https://api.honeywellhome.com/v2/locations')
   })
 
   it('should have correct DeviceURL', () => {
-    expect(settings.DeviceURL).toBe('https://api.honeywell.com/v2/devices')
+    expect(settings.DeviceURL).toBe('https://api.honeywellhome.com/v2/devices')
   })
 
   it('should have correct HttpMethod types', () => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,22 +17,22 @@ export const PLUGIN_NAME = '@homebridge-plugins/homebridge-resideo'
 /**
  * This is the main url used to access Resideo API
  */
-export const AuthorizeURL = 'https://api.honeywell.com/oauth2/authorize?'
+export const AuthorizeURL = 'https://api.honeywellhome.com/oauth2/authorize?'
 
 /**
  * This is the main url used to access Resideo API
  */
-export const TokenURL = 'https://api.honeywell.com/oauth2/token'
+export const TokenURL = 'https://api.honeywellhome.com/oauth2/token'
 
 /**
  * This is the main url used to access Resideo API
  */
-export const LocationURL = 'https://api.honeywell.com/v2/locations'
+export const LocationURL = 'https://api.honeywellhome.com/v2/locations'
 
 /**
  * This is the main url used to access Resideo API
  */
-export const DeviceURL = 'https://api.honeywell.com/v2/devices'
+export const DeviceURL = 'https://api.honeywellhome.com/v2/devices'
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'OPTIONS' | 'HEAD'
 


### PR DESCRIPTION
## :recycle: Current situation

Oath flow / API is broken - https://github.com/homebridge-plugins/homebridge-resideo/issues/923

## :bulb: Proposed solution

Use the correct API endpoint from honeywell

## :gear: Release Notes

Updates the honeywell API endpoint to the correct `https://api.honeywellhome.com` from the docs

## :heavy_plus_sign: Additional Information

_If applicable, provide additional context in this section._

### Testing

settings tests updated

### Reviewer Nudging

_Where should the reviewer start? what is a good entry point?_
